### PR TITLE
Allow selection of collapsed values without triggering expansion

### DIFF
--- a/src/collapsed.js
+++ b/src/collapsed.js
@@ -40,7 +40,7 @@ export default function inspectCollapsed(object, shallow, name) {
       span.appendChild(inspectName(name));
     }
     span.appendChild(document.createTextNode(tag));
-    span.addEventListener("click", function(event) {
+    span.addEventListener("mouseup", function(event) {
       if (hasSelection(span)) return;
       event.stopPropagation();
       replace(span, inspectCollapsed(object));
@@ -58,7 +58,7 @@ export default function inspectCollapsed(object, shallow, name) {
     <path d='M7 4L1 8V0z' fill='currentColor' />
   </svg>`;
   a.appendChild(document.createTextNode(`${tag}${arrayish ? " [" : " {"}`));
-  span.addEventListener("click", function(event) {
+  span.addEventListener("mouseup", function(event) {
     if (hasSelection(span)) return;
     event.stopPropagation();
     replace(span, inspectExpanded(object, null, name));

--- a/src/collapsed.js
+++ b/src/collapsed.js
@@ -5,6 +5,16 @@ import inspectName from "./inspectName.js";
 import {inspect, replace} from "./inspect.js";
 import {isown, symbolsof, tagof, valueof} from "./object.js";
 
+function hasSelection(elem) {
+  const sel = window.getSelection();
+  return (
+    sel.type === "Range" &&
+    (sel.containsNode(elem, true) ||
+      sel.anchorNode.isSelfOrDescendant(elem) ||
+      sel.focusNode.isSelfOrDescendant(elem))
+  );
+}
+
 export default function inspectCollapsed(object, shallow, name) {
   const arrayish = isarray(object);
   let tag, fields, next;
@@ -30,7 +40,8 @@ export default function inspectCollapsed(object, shallow, name) {
       span.appendChild(inspectName(name));
     }
     span.appendChild(document.createTextNode(tag));
-    span.addEventListener("mouseup", function(event) {
+    span.addEventListener("click", function(event) {
+      if (hasSelection(span)) return;
       event.stopPropagation();
       replace(span, inspectCollapsed(object));
     });
@@ -43,11 +54,12 @@ export default function inspectCollapsed(object, shallow, name) {
     span.appendChild(inspectName(name));
   }
   const a = span.appendChild(document.createElement("a"));
-  a.innerHTML =`<svg width=8 height=8 class='observablehq--caret'>
+  a.innerHTML = `<svg width=8 height=8 class='observablehq--caret'>
     <path d='M7 4L1 8V0z' fill='currentColor' />
   </svg>`;
   a.appendChild(document.createTextNode(`${tag}${arrayish ? " [" : " {"}`));
-  span.addEventListener("mouseup", function(event) {
+  span.addEventListener("click", function(event) {
+    if (hasSelection(span)) return;
     event.stopPropagation();
     replace(span, inspectExpanded(object, null, name));
   }, true);

--- a/test/inspector.test.js
+++ b/test/inspector.test.js
@@ -34,7 +34,7 @@ describe("Inspector", () => {
   test(".fulfilled(value)", () => {
     inspector.fulfilled([1, 2, 3]);
     expect(elem).toMatchSnapshot();
-    elem.querySelector("a").dispatchEvent(new MouseEvent("click"));
+    elem.querySelector("a").dispatchEvent(new MouseEvent("mouseup"));
     expect(elem).toMatchSnapshot();
   });
 

--- a/test/inspector.test.js
+++ b/test/inspector.test.js
@@ -6,6 +6,13 @@ describe("Inspector", () => {
   beforeEach(() => {
     elem = document.createElement("div");
     inspector = new Inspector(elem);
+    window.getSelection = () => {
+      return {
+        type: 'Caret',
+        removeAllRanges: () => {},
+        containsNode: () => false
+      };
+    };
   });
 
   test("initial state", () => {
@@ -27,7 +34,7 @@ describe("Inspector", () => {
   test(".fulfilled(value)", () => {
     inspector.fulfilled([1, 2, 3]);
     expect(elem).toMatchSnapshot();
-    elem.querySelector("a").dispatchEvent(new MouseEvent("mouseup"));
+    elem.querySelector("a").dispatchEvent(new MouseEvent("click"));
     expect(elem).toMatchSnapshot();
   });
 


### PR DESCRIPTION
This ports some clever logic from devtools ( https://github.com/ChromeDevTools/devtools-frontend/blob/7fbe24c094a53d6a95cbb0d19b4bf889c7dcee53/front_end/dom_extension/DOMExtension.js#L271 ) that that essentially says that if you click on something toggleable and the thing has a selection, then it won't be expanded. This works because:

1. If you just click on it, it expands.
2. If you select it, it doesn't expand (it has a selection)
3. If it's selected and you click on it, the selection is zapped immediately and it expands.