### PR TITLE
First-class support for Immutable.js

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -1,5 +1,6 @@
 <html>
 <link rel="stylesheet" href="https://unpkg.com/tachyons@4.10.0/css/tachyons.min.css"/>
+<script src='https://cdn.jsdelivr.net/npm/immutable@4.0.0-rc.12/dist/immutable.min.js'></script>
 <style>
 :root {
   --syntax_normal: #1b1e23;
@@ -182,7 +183,7 @@ fixed(A, 'aClass')
 fixed(true, 'hasCarrots')
 fixed(undefined, 'isUndefined')
 fixed(/baz/g, 'myRegexp')
-fixed(100n, 'myBigInt')
+fixed(typeof BigInt !== 'undefined' ? BigInt(100) : 100, 'myBigInt')
 fixed(a => {}, 'a')
 fixed(function* a() {}, 'a')
 fixed(async function* a() {}, 'asyncGenerator')
@@ -194,6 +195,16 @@ fixed(new Set([1, 2]), 'mySet')
 fixed({a:2, [Symbol('hi')]: 3}, 'q')
 fixed(new Uint8Array([1, 2, 3]), 'z')
 fixed(new Uint16Array([1, 2, 3]), 'nothign')
+fixed(Immutable.Set([1, 2, 3]), 'immutableSet')
+fixed(Immutable.Set(Array.from({ length: 100 }, (_, i) => i)), 'immutableSet')
+fixed(Immutable.OrderedSet([1, 2, 3]), 'immutableOrderedSet')
+fixed(Immutable.List([1, 2, 3]), 'immutableList')
+fixed(Immutable.List([1, Immutable.List([1, 2, 3]), 3]), 'immutableListNested')
+fixed(Immutable.Stack([1, 2, 3]), 'immutableStack')
+fixed(Immutable.Map([[1, 2], [2, 3], [3, 4]]), 'immutableMap')
+fixed(Immutable.Map([[Immutable.List([1, 2, 3]), 2], [2, 3], [3, 4]]), 'immutableMap')
+fixed(Immutable.OrderedMap([[1, 2], [2, 3], [3, 4]]), 'immutableOrderedMap')
+fixed(Immutable.Record({a: 1})({ b:2}), 'immutableRecord')
 fixed("A short string", 'myString')
 fixed({objProp: "A short string"}, 'someVarName')
 fixed(["A short string"], 'An array')

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "clean-css-cli": "^4.2.1",
     "eslint": "^5.10.0",
     "husky": "^2.3.0",
+    "immutable": "^4.0.0-rc.12",
     "jest": "^24.8.0",
     "rollup": "^1.12.3",
     "rollup-plugin-node-resolve": "^5.0.0",

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -3,9 +3,19 @@ const SYMBOLS = [
   { symbol: "@@__IMMUTABLE_KEYED__@@", name: "Keyed", modifier: true },
   { symbol: "@@__IMMUTABLE_LIST__@@", name: "List", arrayish: true },
   { symbol: "@@__IMMUTABLE_MAP__@@", name: "Map" },
-  { symbol: "@@__IMMUTABLE_ORDERED__@@", name: "Ordered", modifier: true, prefix: true },
+  {
+    symbol: "@@__IMMUTABLE_ORDERED__@@",
+    name: "Ordered",
+    modifier: true,
+    prefix: true
+  },
   { symbol: "@@__IMMUTABLE_RECORD__@@", name: "Record" },
-  { symbol: "@@__IMMUTABLE_SET__@@", name: "Set", arrayish: true, setish: true },
+  {
+    symbol: "@@__IMMUTABLE_SET__@@",
+    name: "Set",
+    arrayish: true,
+    setish: true
+  },
   { symbol: "@@__IMMUTABLE_STACK__@@", name: "Stack", arrayish: true }
 ];
 
@@ -14,10 +24,10 @@ export function immutableName(obj) {
   if (!symbols.length) return;
 
   let name = symbols.find(s => !s.modifier);
-  let prefix = name.name === 'Map' && symbols.find(s => s.modifier && s.prefix);
+  let prefix = name.name === "Map" && symbols.find(s => s.modifier && s.prefix);
 
-  const arrayish = symbols.find(s => s.arrayish);
-  const setish = symbols.find(s => s.setish);
+  const arrayish = symbols.some(s => s.arrayish);
+  const setish = symbols.some(s => s.setish);
 
   return {
     name: `${prefix ? prefix.name : ""}${name.name}`,

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -24,8 +24,8 @@ export function immutableName(obj) {
     let symbols = SYMBOLS.filter(({ symbol }) => obj[symbol] === true);
     if (!symbols.length) return;
 
-    let name = symbols.find(s => !s.modifier);
-    let prefix =
+    const name = symbols.find(s => !s.modifier);
+    const prefix =
       name.name === "Map" && symbols.find(s => s.modifier && s.prefix);
 
     const arrayish = symbols.some(s => s.arrayish);

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -20,19 +20,24 @@ const SYMBOLS = [
 ];
 
 export function immutableName(obj) {
-  let symbols = SYMBOLS.filter(({ symbol }) => obj[symbol] === true);
-  if (!symbols.length) return;
+  try {
+    let symbols = SYMBOLS.filter(({ symbol }) => obj[symbol] === true);
+    if (!symbols.length) return;
 
-  let name = symbols.find(s => !s.modifier);
-  let prefix = name.name === "Map" && symbols.find(s => s.modifier && s.prefix);
+    let name = symbols.find(s => !s.modifier);
+    let prefix =
+      name.name === "Map" && symbols.find(s => s.modifier && s.prefix);
 
-  const arrayish = symbols.some(s => s.arrayish);
-  const setish = symbols.some(s => s.setish);
+    const arrayish = symbols.some(s => s.arrayish);
+    const setish = symbols.some(s => s.setish);
 
-  return {
-    name: `${prefix ? prefix.name : ""}${name.name}`,
-    symbols,
-    arrayish: arrayish && !setish,
-    setish
-  };
+    return {
+      name: `${prefix ? prefix.name : ""}${name.name}`,
+      symbols,
+      arrayish: arrayish && !setish,
+      setish
+    };
+  } catch (e) {
+    return null;
+  }
 }

--- a/src/immutable.js
+++ b/src/immutable.js
@@ -1,0 +1,28 @@
+const SYMBOLS = [
+  { symbol: "@@__IMMUTABLE_INDEXED__@@", name: "Indexed", modifier: true },
+  { symbol: "@@__IMMUTABLE_KEYED__@@", name: "Keyed", modifier: true },
+  { symbol: "@@__IMMUTABLE_LIST__@@", name: "List", arrayish: true },
+  { symbol: "@@__IMMUTABLE_MAP__@@", name: "Map" },
+  { symbol: "@@__IMMUTABLE_ORDERED__@@", name: "Ordered", modifier: true, prefix: true },
+  { symbol: "@@__IMMUTABLE_RECORD__@@", name: "Record" },
+  { symbol: "@@__IMMUTABLE_SET__@@", name: "Set", arrayish: true, setish: true },
+  { symbol: "@@__IMMUTABLE_STACK__@@", name: "Stack", arrayish: true }
+];
+
+export function immutableName(obj) {
+  let symbols = SYMBOLS.filter(({ symbol }) => obj[symbol] === true);
+  if (!symbols.length) return;
+
+  let name = symbols.find(s => !s.modifier);
+  let prefix = name.name === 'Map' && symbols.find(s => s.modifier && s.prefix);
+
+  const arrayish = symbols.find(s => s.arrayish);
+  const setish = symbols.find(s => s.setish);
+
+  return {
+    name: `${prefix ? prefix.name : ""}${name.name}`,
+    symbols,
+    arrayish: arrayish && !setish,
+    setish
+  };
+}

--- a/test/__snapshots__/inspector.test.js.snap
+++ b/test/__snapshots__/inspector.test.js.snap
@@ -166,6 +166,406 @@ exports[`Inspector initial state 1`] = `
 />
 `;
 
+exports[`immutable Immutable.List 1`] = `
+<div
+  class="observablehq"
+>
+  <span
+    class="observablehq--collapsed observablehq--inspect"
+  >
+    <a>
+      <svg
+        class="observablehq--caret"
+        height="8"
+        width="8"
+      >
+        
+    
+        <path
+          d="M7 4L1 8V0z"
+          fill="currentColor"
+        />
+        
+  
+      </svg>
+      Immutable.List(2) [
+    </a>
+    <span>
+      <span
+        class="observablehq--number"
+      >
+        1
+      </span>
+    </span>
+    , 
+    <span>
+      <span
+        class="observablehq--number"
+      >
+        2
+      </span>
+    </span>
+    ]
+  </span>
+</div>
+`;
+
+exports[`immutable Immutable.List 2`] = `
+<div
+  class="observablehq"
+>
+  <span
+    class="observablehq--expanded observablehq--inspect"
+  >
+    <a>
+      <svg
+        class="observablehq--caret"
+        height="8"
+        width="8"
+      >
+        
+    
+        <path
+          d="M4 7L0 1h8z"
+          fill="currentColor"
+        />
+        
+  
+      </svg>
+      Immutable.List(2) [
+    </a>
+    <div
+      class="observablehq--field"
+    >
+      <span
+        class="true"
+      >
+          0
+      </span>
+      : 
+      <span>
+        <span
+          class="observablehq--number"
+        >
+          1
+        </span>
+      </span>
+    </div>
+    <div
+      class="observablehq--field"
+    >
+      <span
+        class="true"
+      >
+          1
+      </span>
+      : 
+      <span>
+        <span
+          class="observablehq--number"
+        >
+          2
+        </span>
+      </span>
+    </div>
+    ]
+  </span>
+</div>
+`;
+
+exports[`immutable Immutable.Map 1`] = `
+<div
+  class="observablehq"
+>
+  <span
+    class="observablehq--collapsed observablehq--inspect"
+  >
+    <a>
+      <svg
+        class="observablehq--caret"
+        height="8"
+        width="8"
+      >
+        
+    
+        <path
+          d="M7 4L1 8V0z"
+          fill="currentColor"
+        />
+        
+  
+      </svg>
+      Immutable.Map(1) {
+    </a>
+    <span
+      class="observablehq--key"
+    >
+      1
+    </span>
+    : 
+    <span>
+      <span
+        class="observablehq--number"
+      >
+        2
+      </span>
+    </span>
+    }
+  </span>
+</div>
+`;
+
+exports[`immutable Immutable.Map 2`] = `
+<div
+  class="observablehq"
+>
+  <span
+    class="observablehq--expanded observablehq--inspect"
+  >
+    <a>
+      <svg
+        class="observablehq--caret"
+        height="8"
+        width="8"
+      >
+        
+    
+        <path
+          d="M4 7L0 1h8z"
+          fill="currentColor"
+        />
+        
+  
+      </svg>
+      Immutable.Map(1) {
+    </a>
+    <div
+      class="observablehq--field"
+    >
+      <span
+        class="observablehq--key"
+      >
+          1
+      </span>
+      : 
+      <span>
+        <span
+          class="observablehq--number"
+        >
+          2
+        </span>
+      </span>
+    </div>
+    }
+  </span>
+</div>
+`;
+
+exports[`immutable Immutable.Record 1`] = `
+<div
+  class="observablehq"
+>
+  <span
+    class="observablehq--collapsed observablehq--inspect"
+  >
+    <a>
+      <svg
+        class="observablehq--caret"
+        height="8"
+        width="8"
+      >
+        
+    
+        <path
+          d="M7 4L1 8V0z"
+          fill="currentColor"
+        />
+        
+  
+      </svg>
+      Immutable.Record {
+    </a>
+    <span
+      class="observablehq--key"
+    >
+      a
+    </span>
+    : 
+    <span>
+      <span
+        class="observablehq--number"
+      >
+        21
+      </span>
+    </span>
+    }
+  </span>
+</div>
+`;
+
+exports[`immutable Immutable.Record 2`] = `
+<div
+  class="observablehq"
+>
+  <span
+    class="observablehq--expanded observablehq--inspect"
+  >
+    <a>
+      <svg
+        class="observablehq--caret"
+        height="8"
+        width="8"
+      >
+        
+    
+        <path
+          d="M4 7L0 1h8z"
+          fill="currentColor"
+        />
+        
+  
+      </svg>
+      Immutable.Record {
+    </a>
+    <div
+      class="observablehq--field"
+    >
+      <span
+        class="observablehq--key"
+      >
+          a
+      </span>
+      : 
+      <span>
+        <span
+          class="observablehq--number"
+        >
+          21
+        </span>
+      </span>
+    </div>
+    }
+  </span>
+</div>
+`;
+
+exports[`immutable Immutable.Set 1`] = `
+<div
+  class="observablehq"
+>
+  <span
+    class="observablehq--collapsed observablehq--inspect"
+  >
+    <a>
+      <svg
+        class="observablehq--caret"
+        height="8"
+        width="8"
+      >
+        
+    
+        <path
+          d="M7 4L1 8V0z"
+          fill="currentColor"
+        />
+        
+  
+      </svg>
+      Immutable.Set(3) {
+    </a>
+    <span>
+      <span
+        class="observablehq--number"
+      >
+        1
+      </span>
+    </span>
+    , 
+    <span>
+      <span
+        class="observablehq--number"
+      >
+        2
+      </span>
+    </span>
+    , 
+    <span>
+      <span
+        class="observablehq--number"
+      >
+        3
+      </span>
+    </span>
+    }
+  </span>
+</div>
+`;
+
+exports[`immutable Immutable.Set 2`] = `
+<div
+  class="observablehq"
+>
+  <span
+    class="observablehq--expanded observablehq--inspect"
+  >
+    <a>
+      <svg
+        class="observablehq--caret"
+        height="8"
+        width="8"
+      >
+        
+    
+        <path
+          d="M4 7L0 1h8z"
+          fill="currentColor"
+        />
+        
+  
+      </svg>
+      Immutable.Set(3) {
+    </a>
+    <div
+      class="observablehq--field"
+    >
+        
+      <span>
+        <span
+          class="observablehq--number"
+        >
+          1
+        </span>
+      </span>
+    </div>
+    <div
+      class="observablehq--field"
+    >
+        
+      <span>
+        <span
+          class="observablehq--number"
+        >
+          2
+        </span>
+      </span>
+    </div>
+    <div
+      class="observablehq--field"
+    >
+        
+      <span>
+        <span
+          class="observablehq--number"
+        >
+          3
+        </span>
+      </span>
+    </div>
+    }
+  </span>
+</div>
+`;
+
 exports[`into formats a string with JSON syntax if it doesn’t have many newlines 1`] = `
 <div>
   <div

--- a/test/inspector.test.js
+++ b/test/inspector.test.js
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 const { Inspector } = require("../dist/inspector.js");
+const Immutable = require("immutable");
 
 describe("Inspector", () => {
   let inspector, elem;
@@ -8,7 +9,7 @@ describe("Inspector", () => {
     inspector = new Inspector(elem);
     window.getSelection = () => {
       return {
-        type: 'Caret',
+        type: "Caret",
         removeAllRanges: () => {},
         containsNode: () => false
       };
@@ -94,5 +95,44 @@ describe("into", () => {
       "myString"
     );
     expect(container).toMatchSnapshot();
+  });
+});
+
+describe("immutable", () => {
+  let inspector, elem;
+  beforeEach(() => {
+    elem = document.createElement("div");
+    inspector = new Inspector(elem);
+    window.getSelection = () => {
+      return {
+        type: "Caret",
+        removeAllRanges: () => {},
+        containsNode: () => false
+      };
+    };
+  });
+  test("Immutable.Set", () => {
+    inspector.fulfilled(Immutable.Set([1, 2, 3]));
+    expect(elem).toMatchSnapshot();
+    elem.querySelector("a").dispatchEvent(new MouseEvent("mouseup"));
+    expect(elem).toMatchSnapshot();
+  });
+  test("Immutable.Map", () => {
+    inspector.fulfilled(Immutable.Map([[1, 2]]));
+    expect(elem).toMatchSnapshot();
+    elem.querySelector("a").dispatchEvent(new MouseEvent("mouseup"));
+    expect(elem).toMatchSnapshot();
+  });
+  test("Immutable.List", () => {
+    inspector.fulfilled(Immutable.List([1, 2]));
+    expect(elem).toMatchSnapshot();
+    elem.querySelector("a").dispatchEvent(new MouseEvent("mouseup"));
+    expect(elem).toMatchSnapshot();
+  });
+  test("Immutable.Record", () => {
+    inspector.fulfilled(Immutable.Record({ a: 1 })({ a: 21 }));
+    expect(elem).toMatchSnapshot();
+    elem.querySelector("a").dispatchEvent(new MouseEvent("mouseup"));
+    expect(elem).toMatchSnapshot();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1524,6 +1524,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
 
+immutable@^4.0.0-rc.12:
+  version "4.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
+  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
+
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"


### PR DESCRIPTION
Does what it says on the tin: adds support for [immutable-js](https://immutable-js.github.io/immutable-js/) values with the inspector. For immutable-js users, this is a pretty big improvement.

Mostly just to scratch the itch - I'm not sure that the % of users who use immutable is worth the complexity, though imho it's also a rather small bump in complexity.

<img width="1052" alt="image" src="https://user-images.githubusercontent.com/32314/58905749-58e83800-86bf-11e9-9ef2-38277ad71dd5.png">
