### PR TITLE
Permit prototype inspection

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "bracketSpacing": false
+}

--- a/demo.html
+++ b/demo.html
@@ -97,6 +97,10 @@ a[href],
   color: var(--syntax_key);
 }
 
+.observablehq--prototype-key {
+  color: #aaa;
+}
+
 .observablehq--empty {
   font-style: oblique;
 }
@@ -172,7 +176,7 @@ function rejected(input, name) {
   (new Inspector(demos.appendChild(document.createElement('div')))).rejected(input, name);
 }
 
-class A {}
+class A { b() {} }
 fixed([1, 2, 3, [2, 3]], 'b')
 fixed(function a() {}, 'a')
 fixed(new A(), 'aClassInstance')

--- a/demo.html
+++ b/demo.html
@@ -177,6 +177,7 @@ function rejected(input, name) {
 }
 
 class A { b() {} }
+A.prototype.hi = 'hi';
 fixed([1, 2, 3, [2, 3]], 'b')
 fixed(function a() {}, 'a')
 fixed(new A(), 'aClassInstance')

--- a/src/collapsed.js
+++ b/src/collapsed.js
@@ -16,7 +16,7 @@ function hasSelection(elem) {
   );
 }
 
-export default function inspectCollapsed(object, shallow, name) {
+export default function inspectCollapsed(object, shallow, name, proto) {
   let arrayish = isarray(object);
   let tag, fields, next, n;
 
@@ -66,7 +66,7 @@ export default function inspectCollapsed(object, shallow, name) {
   span.addEventListener("mouseup", function(event) {
     if (hasSelection(span)) return;
     event.stopPropagation();
-    replace(span, inspectExpanded(object, null, name));
+    replace(span, inspectExpanded(object, null, name, proto));
   }, true);
 
   fields = fields(object);

--- a/src/expanded.js
+++ b/src/expanded.js
@@ -125,11 +125,6 @@ function* iterateImArray(array) {
 }
 
 function* iterateProto(object) {
-  for (const key in object) {
-    if (isown(object, key)) {
-      yield formatField(key, valueof(object, key), "observablehq--key");
-    }
-  }
   for (const key in Object.getOwnPropertyDescriptors(object)) {
     yield formatField(key, valueof(object, key), "observablehq--key");
   }

--- a/src/expanded.js
+++ b/src/expanded.js
@@ -1,11 +1,11 @@
 import dispatch from "./dispatch.js";
 import inspectName from "./inspectName.js";
-import { isarray, isindex } from "./array.js";
+import {isarray, isindex} from "./array.js";
 import inspectCollapsed from "./collapsed.js";
 import formatSymbol from "./formatSymbol.js";
-import { inspect, replace } from "./inspect.js";
-import { isown, symbolsof, tagof, valueof } from "./object.js";
-import { immutableName } from "./immutable.js";
+import {inspect, replace} from "./inspect.js";
+import {isown, symbolsof, tagof, valueof} from "./object.js";
+import {immutableName} from "./immutable.js";
 
 export default function inspectExpanded(object, _, name, proto) {
   let arrayish = isarray(object);

--- a/src/expanded.js
+++ b/src/expanded.js
@@ -7,6 +7,8 @@ import {inspect, replace} from "./inspect.js";
 import {isown, symbolsof, tagof, valueof} from "./object.js";
 import {immutableName} from "./immutable.js";
 
+const {getPrototypeOf, getOwnPropertyDescriptors} = Object;
+
 export default function inspectExpanded(object, _, name, proto) {
   let arrayish = isarray(object);
   let tag, fields, next, n;
@@ -125,7 +127,7 @@ function* iterateImArray(array) {
 }
 
 function* iterateProto(object) {
-  for (const key in Object.getOwnPropertyDescriptors(object)) {
+  for (const key in getOwnPropertyDescriptors(object)) {
     yield formatField(key, valueof(object, key), "observablehq--key");
   }
   for (const symbol of symbolsof(object)) {
@@ -136,8 +138,9 @@ function* iterateProto(object) {
     );
   }
 
-  if (Object.getPrototypeOf(object)) {
-    yield formatPrototype(Object.getPrototypeOf(object));
+  const proto = getPrototypeOf(object);
+  if (proto) {
+    yield formatPrototype(proto);
   }
 }
 
@@ -155,8 +158,9 @@ function* iterateObject(object) {
     );
   }
 
-  if (Object.getPrototypeOf(object)) {
-    yield formatPrototype(Object.getPrototypeOf(object));
+  const proto = getPrototypeOf(object);
+  if (proto) {
+    yield formatPrototype(proto);
   }
 }
 

--- a/src/inspect.js
+++ b/src/inspect.js
@@ -12,7 +12,7 @@ import {FORBIDDEN} from "./object.js";
 
 const {prototype: {toString}} = Object;
 
-export function inspect(value, shallow, expand, name) {
+export function inspect(value, shallow, expand, name, proto) {
   let type = typeof value;
   switch (type) {
     case "boolean":
@@ -30,7 +30,7 @@ export function inspect(value, shallow, expand, name) {
         case "[object RegExp]": { type = "regexp", value = formatRegExp(value, name); break; }
         case "[object Error]": // https://github.com/lodash/lodash/blob/master/isError.js#L26
         case "[object DOMException]": { type = "error", value = formatError(value, name); break; }
-        default: return (expand ? inspectExpanded : inspectCollapsed)(value, shallow, name);
+        default: return (expand ? inspectExpanded : inspectCollapsed)(value, shallow, name, proto);
       }
       break;
     }

--- a/src/style.css
+++ b/src/style.css
@@ -71,6 +71,10 @@
   color: var(--syntax_key);
 }
 
+.observablehq--prototype-key {
+  color: #aaa;
+}
+
 .observablehq--empty {
   font-style: oblique;
 }


### PR DESCRIPTION
Fixes #43 by allowing one to browse through prototype chains and the non-enumerable prototype methods and properties. Nifty for FileAttachment and DatabaseConnector.