### PR TITLE
Use [[Prototype]].

### DIFF
--- a/src/expanded.js
+++ b/src/expanded.js
@@ -176,8 +176,7 @@ function formatPrototype(value) {
   const span = item.appendChild(document.createElement("span"));
   item.className = "observablehq--field";
   span.className = "observablehq--prototype-key";
-  const name = value.constructor.name;
-  span.textContent = `  <${name} prototype>`;
+  span.textContent = `  [[Prototype]]`;
   item.appendChild(document.createTextNode(": "));
   item.appendChild(inspect(value, undefined, undefined, undefined, true));
   return item;

--- a/src/expanded.js
+++ b/src/expanded.js
@@ -176,7 +176,7 @@ function formatPrototype(value) {
   const span = item.appendChild(document.createElement("span"));
   item.className = "observablehq--field";
   span.className = "observablehq--prototype-key";
-  span.textContent = `  [[Prototype]]`;
+  span.textContent = `  <prototype>`;
   item.appendChild(document.createTextNode(": "));
   item.appendChild(inspect(value, undefined, undefined, undefined, true));
   return item;


### PR DESCRIPTION
Adopting the convention from https://www.ecma-international.org/ecma-262/5.1/#sec-15.2.3.2, which also appears on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf