### PR TITLE
changed the string shortening to put the ... at the end instead of the middle

### DIFF
--- a/src/formatString.js
+++ b/src/formatString.js
@@ -44,7 +44,7 @@ export default function formatString(string, shallow, expanded, name) {
   const textValue = span.appendChild(document.createElement("span"));
   textValue.className = "observablehq--string";
   textValue.textContent = JSON.stringify(string.length > 100 ?
-    `${string.slice(0, 50)}…${string.slice(-49)}` : string);
+    `${string.slice(0, 99)} …` : string);
   return span;
 }
 


### PR DESCRIPTION
Based on user request in the D3 slack. I think this made sense to do. Unless someone objects. I also liked the space in this case, since it makes it a bit less crowded at the end of the string.
#123 