### PR TITLE
fix crash in hasSelection

### DIFF
--- a/src/collapsed.js
+++ b/src/collapsed.js
@@ -11,8 +11,8 @@ function hasSelection(elem) {
   return (
     sel.type === "Range" &&
     (sel.containsNode(elem, true) ||
-      sel.anchorNode.isSelfOrDescendant(elem) ||
-      sel.focusNode.isSelfOrDescendant(elem))
+      elem.contains(sel.anchorNode) ||
+      elem.contains(sel.focusNode))
   );
 }
 


### PR DESCRIPTION
Fixes some bogus code in #41 that perhaps never worked — it was dependent on [nonstandard extensions](https://github.com/ChromeDevTools/devtools-frontend/blob/7fbe24c094a53d6a95cbb0d19b4bf889c7dcee53/front_end/dom_extension/DOMExtension.js#L642-L648) to the `Node` interface that appear to be specific to Chrome devtools. So instead we use the standard methods (which probably behave slightly differently with respect to shadow roots, but I don’t think this matters to us — and at any rate if it’s better than crashing).